### PR TITLE
fixed xcode compiler warning

### DIFF
--- a/PulsingHalo/PulsingHaloLayer.m
+++ b/PulsingHalo/PulsingHaloLayer.m
@@ -17,6 +17,7 @@
 
 
 @implementation PulsingHaloLayer
+@dynamic repeatCount;
 
 - (id)initWithRepeatCount:(float) repeatCount
 {


### PR DESCRIPTION
on Xcode 6.3, PulsingHaloLayer.h generates warning 

`Auto property synthesis will not synthesize property 'repeatCount'; it will be implemented by its superclass, use @dynamic to acknowledge intention`

added @dynamic to implementation to remove warning. 