### PR TITLE
Added properties documentation

### DIFF
--- a/PulsingHalo/MultiplePulsingHaloLayer.h
+++ b/PulsingHalo/MultiplePulsingHaloLayer.h
@@ -10,28 +10,75 @@
 
 @interface MultiplePulsingHaloLayer : CALayer
 
-@property (nonatomic, assign) CGFloat radius;                   // default: 60pt
+/**
+ *	The default value of this property is @c 60pt.
+ */
+@property (nonatomic, assign) CGFloat radius;
 @property (nonatomic, assign) CGColorRef haloLayerColor;        // color of halo layers
 
 /* properties below should be set before calling "buildSublayers" */
-@property (nonatomic, assign) CGFloat fromValueForRadius;       // default: 0.0
-@property (nonatomic, assign) CGFloat fromValueForAlpha;        // default: 0.45
-@property (nonatomic, assign) CGFloat keyTimeForHalfOpacity;    // default: 0.2 (range: 0 < keyTime < 1)
-@property (nonatomic, assign) NSTimeInterval animationDuration; // default: 3s
-@property (nonatomic, assign) NSTimeInterval pulseInterval;     // default: 0s
-@property (nonatomic, assign) NSTimeInterval startInterval;     // if there are two more halo layer, this value presents the interval between their first start time, default: 1s
-@property (nonatomic, assign) CGFloat animationRepeatCount;     // default: INFINITY
-@property (nonatomic, assign) int haloLayerNumber;              // default: 3
-@property (nonatomic, assign) BOOL useTimingFunction;           // default: YES should use timingFunction for animation
+
+/**
+ *	The default value of this property is @c 0.0.
+ */
+@property (nonatomic, assign) CGFloat fromValueForRadius;
+
+/**
+ *	The default value of this property is @c 0.45.
+ */
+@property (nonatomic, assign) CGFloat fromValueForAlpha;
+
+/**
+ *	The value of this property should be ranging from @c 0 to @c 1 (exclusive).
+ *
+ *	The default value of this property is @c 0.2.
+ */
+@property (nonatomic, assign) CGFloat keyTimeForHalfOpacity;
+
+/**
+ *	The animation duration in seconds.
+ *
+ *	The default value of this property is @c 3.
+ */
+@property (nonatomic, assign) NSTimeInterval animationDuration;
+
+/**
+ *	The animation interval in seconds.
+ *
+ *	The default value of this property is @c 0.
+ */
+@property (nonatomic, assign) NSTimeInterval pulseInterval;
+
+/**
+ *	The animation delay in seconds.
+ *
+ *	The default value of this property is @c 1.
+ */
+@property (nonatomic, assign) NSTimeInterval startInterval;
+
+/**
+ *	The default value of this property is @c INFINITY.
+ */
+@property (nonatomic, assign) CGFloat animationRepeatCount;
+
+/**
+ *	The default value of this property is @c 3.
+ */
+@property (nonatomic, assign) int haloLayerNumber;
+
+/**
+ *	The default value of this property is @c YES.
+ */
+@property (nonatomic, assign) BOOL useTimingFunction;
 
 
 
 - (id)initWithHaloLayerNum:(int)num andStartInterval:(NSTimeInterval)interval;
 
 /**
- Some properties must be set before calling this method. Like "haloLayerNumber" "startInterval" "animationDuration" and so on
- except "radius" "haloLayerColor" "backgroundColor". If you want to change some properties like "haloLayerNumber" when the
- animation is running, you have to create a new instance.
+ *	@remarks Some properties must be set before calling this method (@c haloLayerNumber, @c startInterval, @c animationDuration, etc.).
+ *	Properties @c radius, @c haloLayerColor, @c backgroundColor can be set after calling this method. Also, if you want to change some
+ *	properties like @c haloLayerNumber when the animation is running, you have to create a new instance.
  */
 - (void)buildSublayers;
 

--- a/PulsingHalo/PulsingHaloLayer.h
+++ b/PulsingHalo/PulsingHaloLayer.h
@@ -14,14 +14,51 @@
 
 @interface PulsingHaloLayer : CALayer
 
-@property (nonatomic, assign) CGFloat radius;                   // default: 60pt
-@property (nonatomic, assign) CGFloat fromValueForRadius;       // default: 0.0
-@property (nonatomic, assign) CGFloat fromValueForAlpha;        // default: 0.45
-@property (nonatomic, assign) CGFloat keyTimeForHalfOpacity;    // default: 0.2 (range: 0 < keyTime < 1)
-@property (nonatomic, assign) NSTimeInterval animationDuration; // default: 3s
-@property (nonatomic, assign) NSTimeInterval pulseInterval;     // default: 0s
-@property (nonatomic, assign) float repeatCount;                // default: INFINITY
-@property (nonatomic, assign) BOOL useTimingFunction;           // default: YES should use timingFunction for animation
+/**
+ *	The default value of this property is @c 60pt.
+ */
+@property (nonatomic, assign) CGFloat radius;
+
+/**
+ *	The default value of this property is @c 0.0.
+ */
+@property (nonatomic, assign) CGFloat fromValueForRadius;
+
+/**
+ *	The default value of this property is @c 0.45.
+ */
+@property (nonatomic, assign) CGFloat fromValueForAlpha;
+
+/**
+ *	The value of this property should be ranging from @c 0 to @c 1 (exclusive).
+ *
+ *	The default value of this property is @c 0.2.
+ */
+@property (nonatomic, assign) CGFloat keyTimeForHalfOpacity;
+
+/**
+ *	The animation duration in seconds.
+ *
+ *	The default value of this property is @c 3.
+ */
+@property (nonatomic, assign) NSTimeInterval animationDuration;
+
+/**
+ *	The animation interval in seconds.
+ *
+ *	The default value of this property is @c 0.
+ */
+@property (nonatomic, assign) NSTimeInterval pulseInterval;
+
+/**
+ *	The default value of this property is @c INFINITY.
+ */
+@property (nonatomic, assign) float repeatCount;
+
+/**
+ *	The default value of this property is @c YES.
+ */
+@property (nonatomic, assign) BOOL useTimingFunction;
 
 - (id)initWithRepeatCount:(float)repeatCount;
 

--- a/PulsingHalo/PulsingHaloLayer.m
+++ b/PulsingHalo/PulsingHaloLayer.m
@@ -105,8 +105,10 @@
 
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag {
 
-    [self removeAllAnimations];
-    [self removeFromSuperlayer];
+	if (flag) {
+        [self removeAllAnimations];
+        [self removeFromSuperlayer];
+	}
 }
 
 @end


### PR DESCRIPTION
The default values or explanations were not showing up in the quick info tooltip (<kbd>alt</kbd> + <kbd>click</kbd>).

More info would be great but I don't have time now to figure out what each property does. It would be great if you could continue this :smiley:. Documentation is very important.

Fixed issue #16.
