### PR TITLE
Omitting headers for pods in duplicate imports

### DIFF
--- a/PulsingHalo/PulsingHalo.h
+++ b/PulsingHalo/PulsingHalo.h
@@ -16,5 +16,9 @@ FOUNDATION_EXPORT const unsigned char PulsingHaloVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <PulsingHalo/PublicHeader.h>
 
+#if __has_include(<PulsingHalo/PulsingHaloLayer.h>)
+#else
 #import <PulsingHalo/PulsingHaloLayer.h>
+#endif
+
 


### PR DESCRIPTION
This works in the following scenarios

- A project using the pod
- A framework using this pod
- A project that uses a framework who has a dependency to this pod