### PR TITLE
Make the superview reference assign instead of weak

### DIFF
--- a/PulsingHalo/PulsingHaloLayer.m
+++ b/PulsingHalo/PulsingHaloLayer.m
@@ -19,7 +19,7 @@
 @property (nonatomic, strong) CAAnimationGroup *animationGroup;
 
 // for resume
-@property (nonatomic, weak) CALayer *prevSuperlayer;
+@property (nonatomic, assign) CALayer *prevSuperlayer;
 @property (nonatomic, assign) unsigned int prevLayerIndex;
 @property (nonatomic, strong) CAAnimation *prevAnimation;
 @end


### PR DESCRIPTION
@shu223 I'm not totally sure why this comes up when you do a pod update but this does seem to fix it and have the same effect so seems good to me. Also solves:

https://github.com/shu223/PulsingHalo/issues/42